### PR TITLE
refactor: use a more distinctive name for boot assets image

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When developing the agent, after doing your changes, run the following command t
    - You can build against a different Talos version using the `IMAGER_TAG` variable.
    - You can customize the extensions repo references using `EXTENSIONS_*` variables.
 
-   This command will build a container image with a tag like `127.0.0.1:5005/siderolabs/boot-assets:v1.9.0-alpha.0-53-g05c620957-agent-198cabf-dirty`, with the following structure:
+   This command will build a container image with a tag like `127.0.0.1:5005/siderolabs/talos-metal-agent-boot-assets:v1.9.0-alpha.0-53-g05c620957-agent-198cabf-dirty`, with the following structure:
 
    ```text
    Permission     UID:GID       Size  Filetree
@@ -48,7 +48,7 @@ When developing the agent, after doing your changes, run the following command t
 4. Push this image to your local registry:
 
    ```bash
-   make image-boot-assets \
+   make push-boot-assets \
    OUTPUT_REGISTRY_AND_USERNAME=127.0.0.1:5005/siderolabs
    ```
 

--- a/hack/boot-assets/build.sh
+++ b/hack/boot-assets/build.sh
@@ -83,7 +83,7 @@ build_artifacts "arm64"
 
 # build and push the final image containing all the artifacts
 
-FINAL_IMAGE="$OUTPUT_REGISTRY_AND_USERNAME/boot-assets:$PUSH_TAG"
+FINAL_IMAGE="$OUTPUT_REGISTRY_AND_USERNAME/talos-metal-agent-boot-assets:$PUSH_TAG"
 
 cd "$TEMP_DIR"
 

--- a/hack/boot-assets/push.sh
+++ b/hack/boot-assets/push.sh
@@ -8,7 +8,7 @@ fi
 
 # build and push the final image containing all the artifacts
 
-FINAL_IMAGE="$OUTPUT_REGISTRY_AND_USERNAME/boot-assets:$PUSH_TAG"
+FINAL_IMAGE="$OUTPUT_REGISTRY_AND_USERNAME/talos-metal-agent-boot-assets:$PUSH_TAG"
 
 docker push "$FINAL_IMAGE"
 


### PR DESCRIPTION
Previous name was too generic to be under the organization, so use a more specific name instead.

Also, do a minor correction in README.