### PR TITLE
chore: bump extensions ref in boot assets image

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -56,7 +56,7 @@ spec:
       - name: EXTENSIONS_REPO
         defaultValue: https://github.com/siderolabs/extensions.git
       - name: EXTENSIONS_REF
-        defaultValue: v1.9.3
+        defaultValue: 95ddb770e659786bf1b6f7ff4c2de233b6ea7f57 # includes https://github.com/siderolabs/extensions/pull/595, todo: bump to the next tag when available
       - name: EXTENSIONS_PATH
         defaultValue: guest-agents/metal-agent
       - name: EXTENSION_DIGESTS_IMAGE

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-02-03T10:35:16Z by kres 987bf4d.
+# Generated on 2025-02-03T17:13:41Z by kres 987bf4d.
 
 # common variables
 
@@ -74,7 +74,7 @@ TOOLCHAIN ?= docker.io/golang:1.23-alpine
 # extra variables
 
 EXTENSIONS_REPO ?= https://github.com/siderolabs/extensions.git
-EXTENSIONS_REF ?= v1.9.3
+EXTENSIONS_REF ?= 95ddb770e659786bf1b6f7ff4c2de233b6ea7f57
 EXTENSIONS_PATH ?= guest-agents/metal-agent
 EXTENSION_DIGESTS_IMAGE ?= ghcr.io/siderolabs/extensions
 IMAGER_REGISTRY_AND_USERNAME ?= ghcr.io/siderolabs


### PR DESCRIPTION
Get the boot assets image (the image containing the agent extension, used in development of the Omni bare-metal infra provider) to be built with the changes introduced in: https://github.com/siderolabs/extensions/pull/595.

We need this for the development/testing processes of the bare-metal infra provider to introduce the "TLS connectivity to the agents" functionality.