### PR TITLE
fix: default to IPMI port 623 when it is unsupported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/siderolabs/talos v1.12.2
 	github.com/siderolabs/talos/pkg/machinery v1.12.2
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
 	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.78.0
@@ -33,6 +34,7 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/containerd/go-cni v1.1.13 // indirect
 	github.com/containernetworking/cni v1.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/gertd/go-pluralize v0.2.1 // indirect
@@ -62,6 +64,7 @@ require (
 	github.com/petermattis/goid v0.0.0-20260113132338-7c7de50cc741 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.6 // indirect
@@ -72,7 +75,6 @@ require (
 	github.com/siderolabs/net v0.4.0 // indirect
 	github.com/siderolabs/protoenc v0.2.4 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
@@ -83,4 +85,5 @@ require (
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ google.golang.org/grpc v1.78.0/go.mod h1:I47qjTo4OKbMkjA/aOOwxDIiPSBofUtQUI5EfpW
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -106,7 +106,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	loggingReverseTunnelServer := a.loggingServiceRegistrar(reverseTunnelServer)
 
 	ipmiClientFactory := func(ctx context.Context) (service.IPMIClient, error) {
-		client, clientErr := ipmi.NewLocalClient(ctx)
+		client, clientErr := ipmi.NewLocalClient(ctx, a.logger)
 		if clientErr != nil {
 			return nil, fmt.Errorf("failed to create IPMI client: %w", clientErr)
 		}

--- a/internal/ipmi/ipmi_test.go
+++ b/internal/ipmi/ipmi_test.go
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ipmi_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	goipmi "github.com/bougou/go-ipmi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/talos-metal-agent/internal/ipmi"
+)
+
+type mockProvider struct {
+	getLanConfigParamForFunc func(ctx context.Context, channelNumber uint8, param goipmi.LanConfigParameter) error
+}
+
+func (m *mockProvider) Close(context.Context) error {
+	return nil
+}
+
+func (m *mockProvider) GetUserAccess(context.Context, uint8, uint8) (*goipmi.GetUserAccessResponse, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func (m *mockProvider) GetUsername(context.Context, uint8) (*goipmi.GetUsernameResponse, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func (m *mockProvider) SetUsername(context.Context, uint8, string) (*goipmi.SetUsernameResponse, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func (m *mockProvider) SetUserPassword(context.Context, uint8, string, bool) (*goipmi.SetUserPasswordResponse, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func (m *mockProvider) SetUserAccess(context.Context, *goipmi.SetUserAccessRequest) (*goipmi.SetUserAccessResponse, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func (m *mockProvider) EnableUser(context.Context, uint8) error {
+	return nil
+}
+
+func (m *mockProvider) GetUsers(context.Context, uint8) ([]*goipmi.User, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func (m *mockProvider) GetLanConfigParamFor(ctx context.Context, channelNumber uint8, param goipmi.LanConfigParameter) error {
+	if m.getLanConfigParamForFunc != nil {
+		return m.getLanConfigParamForFunc(ctx, channelNumber, param)
+	}
+
+	return nil
+}
+
+func TestGetIPPort(t *testing.T) {
+	t.Parallel()
+
+	testIP := net.IPv4(192, 168, 1, 100)
+
+	tests := []struct {
+		name         string
+		mockFunc     func(ctx context.Context, channelNumber uint8, param goipmi.LanConfigParameter) error
+		expectedIP   string
+		expectedPort uint16
+		expectedErr  bool
+	}{
+		{
+			name: "both IP and port supported",
+			mockFunc: func(_ context.Context, _ uint8, param goipmi.LanConfigParameter) error {
+				switch p := param.(type) {
+				case *goipmi.LanConfigParam_IP:
+					p.IP = testIP
+				case *goipmi.LanConfigParam_PrimaryRMCPPort:
+					p.Port = 664
+				}
+
+				return nil
+			},
+			expectedIP:   "192.168.1.100",
+			expectedPort: 664,
+			expectedErr:  false,
+		},
+		{
+			name: "port parameter not supported returns default 623",
+			mockFunc: func(_ context.Context, _ uint8, param goipmi.LanConfigParameter) error {
+				switch p := param.(type) {
+				case *goipmi.LanConfigParam_IP:
+					p.IP = testIP
+				case *goipmi.LanConfigParam_PrimaryRMCPPort:
+					return errors.New("parameter not supported")
+				}
+
+				return nil
+			},
+			expectedIP:   "192.168.1.100",
+			expectedPort: 623,
+			expectedErr:  false,
+		},
+		{
+			name: "port returns zero defaults to 623",
+			mockFunc: func(_ context.Context, _ uint8, param goipmi.LanConfigParameter) error {
+				switch p := param.(type) {
+				case *goipmi.LanConfigParam_IP:
+					p.IP = testIP
+				case *goipmi.LanConfigParam_PrimaryRMCPPort:
+					p.Port = 0
+				}
+
+				return nil
+			},
+			expectedIP:   "192.168.1.100",
+			expectedPort: 623,
+			expectedErr:  false,
+		},
+		{
+			name: "IP parameter fails returns error",
+			mockFunc: func(_ context.Context, _ uint8, param goipmi.LanConfigParameter) error {
+				if _, ok := param.(*goipmi.LanConfigParam_IP); ok {
+					return errors.New("failed to get IP")
+				}
+
+				return nil
+			},
+			expectedIP:   "",
+			expectedPort: 0,
+			expectedErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockProvider{
+				getLanConfigParamForFunc: tt.mockFunc,
+			}
+
+			logger := zaptest.NewLogger(t)
+			client := ipmi.NewClient(mock, logger)
+
+			ip, port, err := client.GetIPPort(t.Context())
+
+			if tt.expectedErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedIP, ip)
+			assert.Equal(t, tt.expectedPort, port)
+		})
+	}
+}


### PR DESCRIPTION
It seems some BMCs do not support the parameter 0x80 to get the IPMI port, so default to that instead of failing.

Add unit tests for it.

Closes siderolabs/talos-metal-agent#20.