### PR TITLE
chore: bump deps and rekres

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-02-02T10:33:24Z by kres dc032d7.
+# Generated on 2026-02-04T12:00:23Z by kres dc032d7.
 
 *
 !api
@@ -10,6 +10,7 @@
 !go.mod
 !go.sum
 !.golangci.yml
+!CHANGELOG.md
 !README.md
 !.markdownlint.json
 !hack/govulncheck.sh

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -56,7 +56,7 @@ spec:
       - name: EXTENSIONS_REPO
         defaultValue: https://github.com/siderolabs/extensions.git
       - name: EXTENSIONS_REF
-        defaultValue: 30eb717bb6ed4e546a1e794414d8e409778880cf # includes https://github.com/siderolabs/extensions/pull/709, todo: bump to the next tag when available
+        defaultValue: f8642756389925f428502feea3e6467d15ae2c5b # includes https://github.com/siderolabs/extensions/pull/965
       - name: EXTENSIONS_PATH
         defaultValue: guest-agents/metal-agent
       - name: EXTENSION_DIGESTS_IMAGE
@@ -66,7 +66,7 @@ spec:
       - name: IMAGER_TAG
         # this must point to a commit where Talos agent mode logic was introduced,
         # i.e., not older than https://github.com/siderolabs/talos/commit/2136358d65ddf6ad040ed62c835b335f99a59399
-        defaultValue: v1.9.6
+        defaultValue: v1.12.2
       - name: PUSH_TAG
         defaultValue: "" # if specified, needs to be a semver tag for the extension validation to not fail
       - name: OUTPUT_REGISTRY_AND_USERNAME
@@ -92,7 +92,7 @@ spec:
         hack/boot-assets/push.sh
     variables: # MAKE SURE to have the same values in the image-boot-assets step as well
       - name: IMAGER_TAG
-        defaultValue: v1.9.6 # point to the same one above
+        defaultValue: v1.12.2 # point to the same one above
       - name: PUSH_TAG
         defaultValue: "" # point to the same one above
       - name: OUTPUT_REGISTRY_AND_USERNAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-02-02T10:33:24Z by kres dc032d7.
+# Generated on 2026-02-04T12:00:23Z by kres dc032d7.
 
 ARG TOOLCHAIN=scratch
 
@@ -11,6 +11,7 @@ FROM docker.io/oven/bun:1.3.6-alpine AS lint-markdown
 WORKDIR /src
 RUN bun i markdownlint-cli@0.47.0 sentences-per-line@0.5.0
 COPY .markdownlint.json .
+COPY ./CHANGELOG.md ./CHANGELOG.md
 COPY ./README.md ./README.md
 RUN bunx markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules markdownlint-sentences-per-line .
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-02-02T10:27:47Z by kres dc032d7.
+# Generated on 2026-02-04T12:00:23Z by kres dc032d7.
 
 # common variables
 
@@ -81,11 +81,11 @@ TOOLCHAIN ?= docker.io/golang:1.25-alpine
 # extra variables
 
 EXTENSIONS_REPO ?= https://github.com/siderolabs/extensions.git
-EXTENSIONS_REF ?= 30eb717bb6ed4e546a1e794414d8e409778880cf
+EXTENSIONS_REF ?= f8642756389925f428502feea3e6467d15ae2c5b
 EXTENSIONS_PATH ?= guest-agents/metal-agent
 EXTENSION_DIGESTS_IMAGE ?= ghcr.io/siderolabs/extensions
 IMAGER_REGISTRY_AND_USERNAME ?= ghcr.io/siderolabs
-IMAGER_TAG ?= v1.9.6
+IMAGER_TAG ?= v1.12.2
 PUSH_TAG ?=
 OUTPUT_REGISTRY_AND_USERNAME ?= ghcr.io/siderolabs
 TEMP_REGISTRY ?= 127.0.0.1:5005

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -241,10 +241,10 @@ golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
-google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 h1:merA0rdPeUV3YIIfHHcH4qBkiQAc1nfCKSI7lB4cV2M=
-google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409/go.mod h1:fl8J1IvUjCilwZzQowmw2b7HQB2eAuYBabMXzWurF+I=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 h1:H86B94AW+VfJWDqFeEbBPhEtHzJwJfTbgE2lZa54ZAQ=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
+google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20 h1:7ei4lp52gK1uSejlA8AZl5AJjeLUOHBQscRQZUgAcu0=
+google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20/go.mod h1:ZdbssH/1SOVnjnDlXzxDHK2MCidiqXtbYccJNzNYPEE=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 h1:Jr5R2J6F6qWyzINc+4AM8t5pfUz6beZpHp678GNrMbE=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
 google.golang.org/grpc v1.78.0 h1:K1XZG/yGDJnzMdd/uZHAkVqJE+xIDOcmdSFZkBUicNc=
 google.golang.org/grpc v1.78.0/go.mod h1:I47qjTo4OKbMkjA/aOOwxDIiPSBofUtQUI5EfpWvW7U=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=


### PR DESCRIPTION
The versions in kres.yaml were forgotten to be updated in the last bump. Bump them as well.